### PR TITLE
Allow php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-phpunit": "^0.12.17",
         "symplify/easy-coding-standard": "^8.3",
-        "phpspec/prophecy-phpunit": "^2.0"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "ext-pdo": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "jangregor/phpstan-prophecy": "^0.8.1",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-phpunit": "^0.12.17",
-        "symplify/easy-coding-standard": "^8.3"
+        "symplify/easy-coding-standard": "^8.3",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f1779d70f1f5774289bf5341918688e",
+    "content-hash": "828948b9974612ae55096211d98e01b6",
     "packages": [],
     "packages-dev": [
         {
@@ -1372,6 +1372,58 @@
                 "stub"
             ],
             "time": "2020-12-19T10:15:11+00:00"
+        },
+        {
+            "name": "phpspec/prophecy-phpunit",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy-phpunit.git",
+                "reference": "9f26c224a2fa335f33e6666cc078fbf388255e87"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/9f26c224a2fa335f33e6666cc078fbf388255e87",
+                "reference": "9f26c224a2fa335f33e6666cc078fbf388255e87",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8",
+                "phpspec/prophecy": "^1.3",
+                "phpunit/phpunit": "^9.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\PhpUnit\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
+            "homepage": "http://phpspec.net",
+            "keywords": [
+                "phpunit",
+                "prophecy"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
+                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.2"
+            },
+            "time": "2023-04-18T11:58:05+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -6112,5 +6164,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/tests/Integration/FlowderTest.php
+++ b/tests/Integration/FlowderTest.php
@@ -14,10 +14,18 @@ use PHPUnit\Framework\TestCase;
 
 final class FlowderTest extends TestCase
 {
-    public function testItLoadsFixturesFromAFileIfGivenThePathToAFile(): void
+    private function getDatabaseConnection(): PDO
     {
         $db = new PDO('sqlite::memory:');
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+
+        return $db;
+    }
+
+    public function testItLoadsFixturesFromAFileIfGivenThePathToAFile(): void
+    {
+        $db = $this->getDatabaseConnection();
 
         $db->exec('CREATE TABLE IF NOT EXISTS loader_test_data (
             column1 INT PRIMARY KEY,
@@ -65,8 +73,7 @@ final class FlowderTest extends TestCase
 
     public function testItTruncatesDataBeforeInsertingAgain(): void
     {
-        $db = new PDO('sqlite::memory:');
-        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db = $this->getDatabaseConnection();
 
         $db->exec('CREATE TABLE IF NOT EXISTS loader_test_data (
             column1 INT PRIMARY KEY,
@@ -119,8 +126,7 @@ final class FlowderTest extends TestCase
 
     public function testItLoadsFixturesFromADirectoryIfGivenThePathToADirectory(): void
     {
-        $db = new PDO('sqlite::memory:');
-        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db = $this->getDatabaseConnection();
 
         $db->exec('CREATE TABLE IF NOT EXISTS empty (column1 INT PRIMARY KEY)');
 

--- a/tests/Integration/Persister/SqlitePersisterTest.php
+++ b/tests/Integration/Persister/SqlitePersisterTest.php
@@ -10,10 +10,18 @@ use PHPUnit\Framework\TestCase;
 
 final class SqlitePersisterTest extends TestCase
 {
-    public function testItRunsOneInsertForASingleRowOfData(): void
+    private function getDatabaseConnection(): PDO
     {
         $db = new PDO('sqlite::memory:');
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+
+        return $db;
+    }
+
+    public function testItRunsOneInsertForASingleRowOfData(): void
+    {
+        $db = $this->getDatabaseConnection();
 
         $db->exec('CREATE TABLE IF NOT EXISTS test_table (
             column1 INT PRIMARY KEY,
@@ -49,8 +57,7 @@ final class SqlitePersisterTest extends TestCase
 
     public function testItRunsOneInsertForMultipleRowsOfData(): void
     {
-        $db = new PDO('sqlite::memory:');
-        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db = $this->getDatabaseConnection();
 
         $db->exec('CREATE TABLE IF NOT EXISTS test_table (
             column1 INT PRIMARY KEY,
@@ -106,8 +113,7 @@ final class SqlitePersisterTest extends TestCase
 
     public function testItCanHandleBrokenForeignKeys(): void
     {
-        $db = new PDO('sqlite::memory:');
-        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db = $this->getDatabaseConnection();
 
         $db->exec('PRAGMA foreign_keys = ON');
 

--- a/tests/Integration/Truncator/SqliteTruncatorTest.php
+++ b/tests/Integration/Truncator/SqliteTruncatorTest.php
@@ -10,10 +10,18 @@ use PHPUnit\Framework\TestCase;
 
 final class SqliteTruncatorTest extends TestCase
 {
-    public function testItTruncatesAGivenTable(): void
+    private function getDatabaseConnection(): PDO
     {
         $db = new PDO('sqlite::memory:');
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+
+        return $db;
+    }
+
+    public function testItTruncatesAGivenTable(): void
+    {
+        $db = $this->getDatabaseConnection();
 
         $db->exec('CREATE TABLE IF NOT EXISTS test_truncate_table (
             column1 INT PRIMARY KEY
@@ -40,8 +48,7 @@ final class SqliteTruncatorTest extends TestCase
 
     public function testItDoesntBreakWhenThereAreForeignKeys(): void
     {
-        $db = new PDO('sqlite::memory:');
-        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db = $this->getDatabaseConnection();
 
         $db->exec('PRAGMA foreign_keys = ON');
 

--- a/tests/Unit/Persister/MySqlPersisterTest.php
+++ b/tests/Unit/Persister/MySqlPersisterTest.php
@@ -8,9 +8,12 @@ use Imjoehaines\Flowder\Persister\MySqlPersister;
 use PDO;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 final class MySqlPersisterTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItRunsOneInsertForASingleRowOfData(): void
     {
         $db = $this->prophesize(PDO::class);

--- a/tests/Unit/Persister/SqlitePersisterTest.php
+++ b/tests/Unit/Persister/SqlitePersisterTest.php
@@ -9,9 +9,12 @@ use PDO;
 use PDOException;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 final class SqlitePersisterTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItRollsbackUponError(): void
     {
         $db = $this->prophesize(PDO::class);

--- a/tests/Unit/Truncator/MySqlTruncatorTest.php
+++ b/tests/Unit/Truncator/MySqlTruncatorTest.php
@@ -7,9 +7,12 @@ namespace Imjoehaines\Flowder\Test\Unit\Truncator;
 use Imjoehaines\Flowder\Truncator\MySqlTruncator;
 use PDO;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 final class MySqlTruncatorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItTruncatesAGivenTable(): void
     {
         $db = $this->prophesize(PDO::class);


### PR DESCRIPTION
PHP 7.x is still (just) in support, make it work concurrently with php 8.0.

While here I fixed the Deprecation warnings we were getting with PHPUnit, as well as making sure that the tests pass regardless of default PDO settings.